### PR TITLE
fix: initialdata immutable memorystore

### DIFF
--- a/packages/handlersjs-core/lib/storage/memory-store.spec.ts
+++ b/packages/handlersjs-core/lib/storage/memory-store.spec.ts
@@ -43,6 +43,18 @@ describe('MemoryStore', () => {
 
   });
 
+  it('can not be mutated by modifying initialdata afterwards', async () => {
+
+    const list: string[] = [ 'abc', 'def' ];
+
+    memoryStore = new MemoryStore([ [ 'key4', list ] ]);
+
+    list.push('123');
+
+    await expect(memoryStore.get('key4')).resolves.toEqual([ 'abc', 'def' ]);
+
+  });
+
   describe('get()', () => {
 
     it('should get a value that has been set', async () => {

--- a/packages/handlersjs-core/lib/storage/memory-store.ts
+++ b/packages/handlersjs-core/lib/storage/memory-store.ts
@@ -48,7 +48,7 @@ export class MemoryStore<M> implements TimedTypedKeyValueStore<M> {
    */
   constructor(initialData?: [keyof M, M[keyof M]][]) {
 
-    this.data = new Map(initialData?.map(([ key, value ]) => [ key, { value, timestamp: Date.now() } ]));
+    this.data = new Map(initialData?.map(([ key, value ]) => [ key, { value: clone(value), timestamp: Date.now() } ]));
 
   }
 


### PR DESCRIPTION
memorystore contents should never be modified without performing a .set()