### PR TITLE
fix: do not remove origin header in cors request handler

### DIFF
--- a/packages/handlersjs-http/lib/handlers/http-cors-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/http-cors-request.handler.spec.ts
@@ -33,6 +33,7 @@ describe('HttpCorsRequestHandler', () => {
         headers: {
           accept: 'text/plain',
           origin: 'http://test.de',
+          ['access-control-request-headers']: 'GET',
         },
       },
     };
@@ -66,14 +67,18 @@ describe('HttpCorsRequestHandler', () => {
       // Check 'noCorsRequestContext' and 'cleanHeaders'
       it('should not pass CORS headers to the child handler.handle', async() => {
 
-        const noCorsHeaderContext = { ...context, request: { ...context.request, headers: { accept: 'text/plain' } } };
-
-        await lastValueFrom(service.handle(noCorsHeaderContext));
+        await lastValueFrom(service.handle(context));
 
         expect(handler.handle).toHaveBeenCalledTimes(1);
-        const expectedToBeCalledWith = { ...context, request: { headers:  cleanHeaders(noCorsHeaderContext.request.headers), method: 'GET', url: new URL('http://example.com') } };
 
-        expect(handler.handle).toHaveBeenCalledWith(expectedToBeCalledWith);
+        expect(handler.handle).toHaveBeenCalledWith(expect.objectContaining({
+          request: expect.objectContaining({
+            headers: {
+              accept: context.request.headers.accept,
+              origin: context.request.headers.origin,
+            },
+          }),
+        }));
 
       });
 

--- a/packages/handlersjs-http/lib/handlers/http-cors-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/http-cors-request.handler.spec.ts
@@ -2,7 +2,6 @@ import { lastValueFrom, of } from 'rxjs';
 import { HttpHandler } from '../models/http-handler';
 import { HttpHandlerContext } from '../models/http-handler-context';
 import { HttpHandlerResponse } from '../models/http-handler-response';
-import { cleanHeaders } from '../util/clean-headers';
 import { HttpCorsOptions, HttpCorsRequestHandler } from './http-cors-request.handler';
 
 describe('HttpCorsRequestHandler', () => {
@@ -33,7 +32,7 @@ describe('HttpCorsRequestHandler', () => {
         headers: {
           accept: 'text/plain',
           origin: 'http://test.de',
-          ['access-control-request-headers']: 'GET',
+          ['access-control-request-method']: 'GET',
         },
       },
     };

--- a/packages/handlersjs-http/lib/handlers/http-cors-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/http-cors-request.handler.ts
@@ -33,7 +33,6 @@ export class HttpCorsRequestHandler implements HttpHandler {
     const cleanRequestHeaders = cleanHeaders(requestHeaders);
 
     const {
-      ['origin']: requestedOrigin,
       /* eslint-disable-next-line @typescript-eslint/no-unused-vars -- destructuring for removal */
       ['access-control-request-method']: requestedMethod,
       ['access-control-request-headers']: requestedHeaders,
@@ -49,6 +48,8 @@ export class HttpCorsRequestHandler implements HttpHandler {
         },
       },
     };
+
+    const { origin: requestedOrigin } = cleanRequestHeaders;
 
     const allowOrigin = origins
       ? origins.includes(requestedOrigin)

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -82,10 +82,10 @@
     ],
     "coverageThreshold": {
       "global": {
-        "statements": 99.36,
-        "branches": 97.88,
-        "functions": 99.16,
-        "lines": 99.53
+        "statements": 99.38,
+        "branches": 98.01,
+        "functions": 99.17,
+        "lines": 99.55
       }
     },
     "coveragePathIgnorePatterns": [


### PR DESCRIPTION
In useid, some handlers need the origin header.
The HttpCorsRequestHandler would remove this one, the only thing this PR does is change the code so the origin is not removed from the headers when passed on to the child handler.