### PR TITLE
feat: add x-powered-by, strict-transport-security and vary header

### DIFF
--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
@@ -342,6 +342,31 @@ describe('RoutedHttpRequestHandler', () => {
 
     });
 
+    it('should not add date header by default', async() => {
+
+      const httpHandlerContext: HttpHandlerContext = {
+        request: { url: new URL('/path1', 'http://example.com'), method: 'GET', headers: {} },
+      };
+
+      const response = await lastValueFrom(routedHttpRequestHandler.handle(httpHandlerContext));
+      expect(response.headers.date).toBeUndefined();
+
+    });
+
+    it('should add date header to the response when specified in the matched route operation', async() => {
+
+      handlerControllerList[0].routes[0].operations[0].addDateHeader = true;
+      routedHttpRequestHandler = new RoutedHttpRequestHandler(handlerControllerList);
+
+      const httpHandlerContext: HttpHandlerContext = {
+        request: { url: new URL('/path1', 'http://example.com'), method: 'GET', headers: {} },
+      };
+
+      const response = await lastValueFrom(routedHttpRequestHandler.handle(httpHandlerContext));
+      expect(response.headers).toEqual(expect.objectContaining({ date: expect.any(String) }));
+
+    });
+
   });
 
 });

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
@@ -30,6 +30,8 @@ describe('RoutedHttpRequestHandler', () => {
   let mockHttpHandler: HttpHandler;
   let preresponseHandler: Handler<HttpHandlerContext, HttpHandlerContext>;
 
+  const poweredBy = 'yabat.be';
+
   beforeEach(() => {
 
     mockHttpHandler = getMockedHttpHandler();
@@ -49,6 +51,7 @@ describe('RoutedHttpRequestHandler', () => {
           } ],
           path: '/path1',
           handler: mockHttpHandler,
+          poweredBy, 
         } ],
       },
       {
@@ -325,6 +328,17 @@ describe('RoutedHttpRequestHandler', () => {
 
       await expect(lastValueFrom(defaultRoutedHttpRequestHandler.handle(httpHandlerContext))).resolves.toEqual({ body: 'defaultHandler mockBody', headers: {}, status:200 });
       expect(defaultHandler.handle).toHaveBeenCalledTimes(1);
+
+    });
+
+    it('should add x-powered-by header to the response when specified in the matched route', async() => {
+
+      const httpHandlerContext: HttpHandlerContext = {
+        request: { url: new URL('/path1', 'http://example.com'), method: 'GET', headers: {} },
+      };
+
+      const response = await lastValueFrom(routedHttpRequestHandler.handle(httpHandlerContext));
+      expect(response.headers).toEqual(expect.objectContaining({ 'x-powered-by': poweredBy }));
 
     });
 

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
@@ -31,6 +31,7 @@ describe('RoutedHttpRequestHandler', () => {
   let preresponseHandler: Handler<HttpHandlerContext, HttpHandlerContext>;
 
   const poweredBy = 'yabat.be';
+  const vary = [ 'Accept', 'Authorization', 'Origin' ];
 
   beforeEach(() => {
 
@@ -45,13 +46,14 @@ describe('RoutedHttpRequestHandler', () => {
           operations: [ {
             method: 'GET',
             publish: true,
+            vary,
           }, {
             method: 'OPTIONS',
             publish: false,
           } ],
           path: '/path1',
           handler: mockHttpHandler,
-          poweredBy, 
+          poweredBy,
         } ],
       },
       {
@@ -364,6 +366,17 @@ describe('RoutedHttpRequestHandler', () => {
 
       const response = await lastValueFrom(routedHttpRequestHandler.handle(httpHandlerContext));
       expect(response.headers).toEqual(expect.objectContaining({ date: expect.any(String) }));
+
+    });
+
+    it('should add vary header to the response when specified in the matched route', async() => {
+
+      const httpHandlerContext: HttpHandlerContext = {
+        request: { url: new URL('/path1', 'http://example.com'), method: 'GET', headers: {} },
+      };
+
+      const response = await lastValueFrom(routedHttpRequestHandler.handle(httpHandlerContext));
+      expect(response.headers).toEqual(expect.objectContaining({ 'vary': vary.join(', ') }));
 
     });
 

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
@@ -342,20 +342,6 @@ describe('RoutedHttpRequestHandler', () => {
 
     });
 
-    it('should add date header to the response when specified in the matched route operation', async() => {
-
-      handlerControllerList[0].routes[0].operations[0].addDateHeader = true;
-      routedHttpRequestHandler = new RoutedHttpRequestHandler(handlerControllerList);
-
-      const httpHandlerContext: HttpHandlerContext = {
-        request: { url: new URL('/path1', 'http://example.com'), method: 'GET', headers: {} },
-      };
-
-      const response = await lastValueFrom(routedHttpRequestHandler.handle(httpHandlerContext));
-      expect(response.headers).toEqual(expect.objectContaining({ date: expect.any(String) }));
-
-    });
-
     it('should add vary header to the response when specified in the matched route', async() => {
 
       const httpHandlerContext: HttpHandlerContext = {

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
@@ -331,14 +331,14 @@ describe('RoutedHttpRequestHandler', () => {
 
     });
 
-    it('should not add date header by default', async() => {
+    it('should not add vary header by default', async() => {
 
       const httpHandlerContext: HttpHandlerContext = {
-        request: { url: new URL('/path1', 'http://example.com'), method: 'GET', headers: {} },
+        request: { url: new URL('/path2', 'http://example.com'), method: 'POST', headers: {} },
       };
 
       const response = await lastValueFrom(routedHttpRequestHandler.handle(httpHandlerContext));
-      expect(response.headers.date).toBeUndefined();
+      expect(response.headers.vary).toBeUndefined();
 
     });
 

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.spec.ts
@@ -30,7 +30,6 @@ describe('RoutedHttpRequestHandler', () => {
   let mockHttpHandler: HttpHandler;
   let preresponseHandler: Handler<HttpHandlerContext, HttpHandlerContext>;
 
-  const poweredBy = 'yabat.be';
   const vary = [ 'Accept', 'Authorization', 'Origin' ];
 
   beforeEach(() => {
@@ -53,7 +52,6 @@ describe('RoutedHttpRequestHandler', () => {
           } ],
           path: '/path1',
           handler: mockHttpHandler,
-          poweredBy,
         } ],
       },
       {
@@ -330,17 +328,6 @@ describe('RoutedHttpRequestHandler', () => {
 
       await expect(lastValueFrom(defaultRoutedHttpRequestHandler.handle(httpHandlerContext))).resolves.toEqual({ body: 'defaultHandler mockBody', headers: {}, status:200 });
       expect(defaultHandler.handle).toHaveBeenCalledTimes(1);
-
-    });
-
-    it('should add x-powered-by header to the response when specified in the matched route', async() => {
-
-      const httpHandlerContext: HttpHandlerContext = {
-        request: { url: new URL('/path1', 'http://example.com'), method: 'GET', headers: {} },
-      };
-
-      const response = await lastValueFrom(routedHttpRequestHandler.handle(httpHandlerContext));
-      expect(response.headers).toEqual(expect.objectContaining({ 'x-powered-by': poweredBy }));
 
     });
 

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -131,6 +131,7 @@ export class RoutedHttpRequestHandler implements HttpHandler {
           headers: {
             ... response.headers,
             ... (request.method === 'OPTIONS') && { Allow: allowedMethods.join(', ') },
+            ... (matchingRouteWithOperation.route.poweredBy) && { 'x-powered-by': matchingRouteWithOperation.route.poweredBy },
           },
         }))
       );

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -121,7 +121,6 @@ export class RoutedHttpRequestHandler implements HttpHandler {
       const requestWithParams = Object.assign(request, { parameters });
       const newContext = { request: requestWithParams, route: matchingRouteWithOperation.route };
       const preResponseHandler = matchingRouteWithOperation.controller.preResponseHandler;
-      const matchingOperation = matchingRouteWithOperation.operation;
 
       return (preResponseHandler
         ? preResponseHandler.handle(newContext)
@@ -133,7 +132,7 @@ export class RoutedHttpRequestHandler implements HttpHandler {
           headers: {
             ... response.headers,
             ... (request.method === 'OPTIONS') && { Allow: allowedMethods.join(', ') },
-            ... (matchingOperation?.vary) && { vary: matchingOperation.vary.join(', ') },
+            ... (matchingRouteWithOperation.operation?.vary) && { vary: matchingRouteWithOperation.operation.vary.join(', ') },
           },
         }))
       );

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -101,9 +101,10 @@ export class RoutedHttpRequestHandler implements HttpHandler {
     const matchingRoutes = match ? this.pathToRouteMap.get(match) : undefined;
 
     if (matchingRoutes?.length) {
-
-      const matchingRouteWithOperation = matchingRoutes.find((r) =>
-        r.route.operations.map((op) => op.method).includes(request.method));
+      
+      const matchingRouteWithOperation = matchingRoutes
+        .map((r) => ({ ...r, operation: r.route.operations.find((op) => op.method === request.method) }))
+        .find((r) => r.operation);
 
       const allowedMethods = matchingRoutes.flatMap((r) => r.route.operations.map((op) => op.method));
 
@@ -120,7 +121,7 @@ export class RoutedHttpRequestHandler implements HttpHandler {
       const requestWithParams = Object.assign(request, { parameters });
       const newContext = { request: requestWithParams, route: matchingRouteWithOperation.route };
       const preResponseHandler = matchingRouteWithOperation.controller.preResponseHandler;
-      const matchingOperation = matchingRouteWithOperation.route.operations.find((op) => op.method === request.method);
+      const matchingOperation = matchingRouteWithOperation.operation;
 
       return (preResponseHandler
         ? preResponseHandler.handle(newContext)

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -120,7 +120,7 @@ export class RoutedHttpRequestHandler implements HttpHandler {
       const requestWithParams = Object.assign(request, { parameters });
       const newContext = { request: requestWithParams, route: matchingRouteWithOperation.route };
       const preResponseHandler = matchingRouteWithOperation.controller.preResponseHandler;
-      const matchingOperation = matchingRouteWithOperation.route.operations.find(op => op.method === request.method);
+      const matchingOperation = matchingRouteWithOperation.route.operations.find((op) => op.method === request.method);
 
       return (preResponseHandler
         ? preResponseHandler.handle(newContext)

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -120,6 +120,7 @@ export class RoutedHttpRequestHandler implements HttpHandler {
       const requestWithParams = Object.assign(request, { parameters });
       const newContext = { request: requestWithParams, route: matchingRouteWithOperation.route };
       const preResponseHandler = matchingRouteWithOperation.controller.preResponseHandler;
+      const matchingOperation = matchingRouteWithOperation.route.operations.find(op => op.method === request.method);
 
       return (preResponseHandler
         ? preResponseHandler.handle(newContext)
@@ -132,6 +133,7 @@ export class RoutedHttpRequestHandler implements HttpHandler {
             ... response.headers,
             ... (request.method === 'OPTIONS') && { Allow: allowedMethods.join(', ') },
             ... (matchingRouteWithOperation.route.poweredBy) && { 'x-powered-by': matchingRouteWithOperation.route.poweredBy },
+            ... (matchingOperation?.addDateHeader) && { date: new Date().toUTCString() },
           },
         }))
       );

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -101,7 +101,7 @@ export class RoutedHttpRequestHandler implements HttpHandler {
     const matchingRoutes = match ? this.pathToRouteMap.get(match) : undefined;
 
     if (matchingRoutes?.length) {
-      
+
       const matchingRouteWithOperation = matchingRoutes
         .map((r) => ({ ...r, operation: r.route.operations.find((op) => op.method === request.method) }))
         .find((r) => r.operation);

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -132,7 +132,6 @@ export class RoutedHttpRequestHandler implements HttpHandler {
           headers: {
             ... response.headers,
             ... (request.method === 'OPTIONS') && { Allow: allowedMethods.join(', ') },
-            ... (matchingRouteWithOperation.route.poweredBy) && { 'x-powered-by': matchingRouteWithOperation.route.poweredBy },
             ... (matchingOperation?.addDateHeader) && { date: new Date().toUTCString() },
             ... (matchingOperation?.vary) && { vary: matchingOperation.vary.join(', ') },
           },

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -132,7 +132,6 @@ export class RoutedHttpRequestHandler implements HttpHandler {
           headers: {
             ... response.headers,
             ... (request.method === 'OPTIONS') && { Allow: allowedMethods.join(', ') },
-            ... (matchingOperation?.addDateHeader) && { date: new Date().toUTCString() },
             ... (matchingOperation?.vary) && { vary: matchingOperation.vary.join(', ') },
           },
         }))

--- a/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/routed-http-request.handler.ts
@@ -134,6 +134,7 @@ export class RoutedHttpRequestHandler implements HttpHandler {
             ... (request.method === 'OPTIONS') && { Allow: allowedMethods.join(', ') },
             ... (matchingRouteWithOperation.route.poweredBy) && { 'x-powered-by': matchingRouteWithOperation.route.poweredBy },
             ... (matchingOperation?.addDateHeader) && { date: new Date().toUTCString() },
+            ... (matchingOperation?.vary) && { vary: matchingOperation.vary.join(', ') },
           },
         }))
       );

--- a/packages/handlersjs-http/lib/models/http-handler-route.spec.ts
+++ b/packages/handlersjs-http/lib/models/http-handler-route.spec.ts
@@ -69,12 +69,22 @@ describe('HttpHandlerRoute', () => {
 
   describe('HttpHandlerRoute', () => {
 
+    class testClass extends HttpHandlerRoute { }
+
     it('should be instantiated correctly', () => {
 
-      class testClass extends HttpHandlerRoute { }
       const object = new testClass(undefined, 'path', undefined);
       expect(object).toBeDefined();
       expect(object).toBeTruthy();
+
+    });
+
+    it('should accept an optional poweredBy parameter', () => {
+
+      const object = new testClass(undefined, 'path', undefined, 'yabat.be');
+      expect(object).toBeDefined();
+      expect(object).toBeTruthy();
+      expect(object.poweredBy).toEqual('yabat.be');
 
     });
 

--- a/packages/handlersjs-http/lib/models/http-handler-route.spec.ts
+++ b/packages/handlersjs-http/lib/models/http-handler-route.spec.ts
@@ -79,15 +79,6 @@ describe('HttpHandlerRoute', () => {
 
     });
 
-    it('should accept an optional poweredBy parameter', () => {
-
-      const object = new testClass(undefined, 'path', undefined, 'yabat.be');
-      expect(object).toBeDefined();
-      expect(object).toBeTruthy();
-      expect(object.poweredBy).toEqual('yabat.be');
-
-    });
-
   });
 
 });

--- a/packages/handlersjs-http/lib/models/http-handler-route.ts
+++ b/packages/handlersjs-http/lib/models/http-handler-route.ts
@@ -46,6 +46,7 @@ export abstract class HttpHandlerOperation {
     public responses?: HttpHandlerOperationResponse[],
     public security?: HttpHandlerOperationSecurityType,
     public addDateHeader?: boolean,
+    public vary?: string[],
   ) {}
 
 }

--- a/packages/handlersjs-http/lib/models/http-handler-route.ts
+++ b/packages/handlersjs-http/lib/models/http-handler-route.ts
@@ -45,6 +45,7 @@ export abstract class HttpHandlerOperation {
     public description?: string,
     public responses?: HttpHandlerOperationResponse[],
     public security?: HttpHandlerOperationSecurityType,
+    public addDateHeader?: boolean,
   ) {}
 
 }

--- a/packages/handlersjs-http/lib/models/http-handler-route.ts
+++ b/packages/handlersjs-http/lib/models/http-handler-route.ts
@@ -45,7 +45,6 @@ export abstract class HttpHandlerOperation {
     public description?: string,
     public responses?: HttpHandlerOperationResponse[],
     public security?: HttpHandlerOperationSecurityType,
-    public addDateHeader?: boolean,
     public vary?: string[],
   ) {}
 

--- a/packages/handlersjs-http/lib/models/http-handler-route.ts
+++ b/packages/handlersjs-http/lib/models/http-handler-route.ts
@@ -57,7 +57,6 @@ export abstract class HttpHandlerRoute<C extends HttpHandlerContext = HttpHandle
     public operations: HttpHandlerOperation[],
     public path: string,
     public handler: HttpHandler<C>,
-    public poweredBy?: string,
   ) {}
 
 }

--- a/packages/handlersjs-http/lib/models/http-handler-route.ts
+++ b/packages/handlersjs-http/lib/models/http-handler-route.ts
@@ -55,6 +55,7 @@ export abstract class HttpHandlerRoute<C extends HttpHandlerContext = HttpHandle
     public operations: HttpHandlerOperation[],
     public path: string,
     public handler: HttpHandler<C>,
+    public poweredBy?: string,
   ) {}
 
 }

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
@@ -265,6 +265,7 @@ describe('NodeHttpRequestResponseHandler', () => {
         200,
         expect.objectContaining({
           'content-length': Buffer.byteLength(body, 'utf-8').toString(),
+          'content-type': 'text/html;',
         }),
       );
 
@@ -281,6 +282,7 @@ describe('NodeHttpRequestResponseHandler', () => {
         200,
         expect.objectContaining({
           'content-length': Buffer.byteLength(body, 'utf-8').toString(),
+          'content-type': 'text/html;',
         }),
       );
 
@@ -367,7 +369,7 @@ describe('NodeHttpRequestResponseHandler', () => {
         'handlers.js',
         { includeSubDomains: true, maxAge: 7200 },
       );
-      
+
       await lastValueFrom(handler.handle(streamMock));
 
       expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
@@ -347,10 +347,24 @@ describe('NodeHttpRequestResponseHandler', () => {
 
     });
 
+    it('should add a x-powered-by response header', async () => {
+
+      await lastValueFrom(handler.handle(streamMock));
+
+      expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          'x-powered-by': 'handlers.js',
+        }),
+      );
+
+    });
+
     it('should write strict-transport-security header to the response', async () => {
 
       handler = new NodeHttpRequestResponseHandler(
         nestedHttpHandler,
+        'handlers.js',
         { includeSubDomains: true, maxAge: 7200 },
       );
       
@@ -369,6 +383,7 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       handler = new NodeHttpRequestResponseHandler(
         nestedHttpHandler,
+        'handlers.js',
         { includeSubDomains: false, maxAge: 5000 },
       );
 

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
@@ -349,6 +349,11 @@ describe('NodeHttpRequestResponseHandler', () => {
 
     it('should write strict-transport-security header to the response', async () => {
 
+      handler = new NodeHttpRequestResponseHandler(
+        nestedHttpHandler,
+        { includeSubDomains: true, maxAge: 7200 },
+      );
+      
       await lastValueFrom(handler.handle(streamMock));
 
       expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
@@ -154,6 +154,7 @@ describe('NodeHttpRequestResponseHandler', () => {
     it('should write the headers to response stream', async () => {
 
       await lastValueFrom(handler.handle(streamMock));
+
       expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
         200,
         expect.objectContaining({
@@ -349,6 +350,7 @@ describe('NodeHttpRequestResponseHandler', () => {
     it('should write strict-transport-security header to the response', async () => {
 
       await lastValueFrom(handler.handle(streamMock));
+
       expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
         200,
         expect.objectContaining({
@@ -359,11 +361,14 @@ describe('NodeHttpRequestResponseHandler', () => {
     });
 
     it('should write strict-transport-security header to the response, but not include "includeSubDomains" if specified', async () => {
+
       handler = new NodeHttpRequestResponseHandler(
         nestedHttpHandler,
         { includeSubDomains: false, maxAge: 5000 },
       );
+
       await lastValueFrom(handler.handle(streamMock));
+
       expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
         200,
         expect.objectContaining({

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
@@ -25,7 +25,6 @@ describe('NodeHttpRequestResponseHandler', () => {
       url: 'http://localhost:3000/test?works=yes',
       method: 'GET',
       buffer,
-
     });
 
     res = new mockhttp.Response();
@@ -155,7 +154,13 @@ describe('NodeHttpRequestResponseHandler', () => {
     it('should write the headers to response stream', async () => {
 
       await lastValueFrom(handler.handle(streamMock));
-      expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(200, { mockKey: 'mockValue', 'content-length': Buffer.byteLength('mockBody', 'utf-8').toString() });
+      expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          mockKey: 'mockValue',
+          'content-length': Buffer.byteLength('mockBody', 'utf-8').toString(),
+        }),
+      );
 
     });
 
@@ -189,7 +194,7 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(200, { 'content-length': Buffer.byteLength(body, 'utf-8').toString() });
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.objectContaining({ 'content-length': Buffer.byteLength(body, 'utf-8').toString() }));
       expect(res.write).toHaveBeenCalledWith(body);
       expect(res.end).toHaveBeenCalledTimes(1);
 
@@ -202,7 +207,14 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(200, { 'content-length': Buffer.byteLength(body, 'base64').toString(), 'content-type': 'text/html; charset=base64' });
+      expect(res.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          'content-length': Buffer.byteLength(body, 'base64').toString(),
+          'content-type': 'text/html; charset=base64',
+        }),
+      );
+
       expect(res.write).toHaveBeenCalledWith(body);
       expect(res.end).toHaveBeenCalledTimes(1);
 
@@ -214,7 +226,7 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(200, { mockKey: 'mockValue' });
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.objectContaining({ mockKey: 'mockValue' }));
       expect(res.write).toHaveBeenCalledTimes(0);
       expect(res.end).toHaveBeenCalledTimes(1);
 
@@ -248,7 +260,12 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(200, { 'content-length': Buffer.byteLength(body, 'utf-8').toString(), 'content-type': 'text/html;' });
+      expect(res.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          'content-length': Buffer.byteLength(body, 'utf-8').toString(),
+        }),
+      );
 
     });
 
@@ -259,7 +276,12 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(200, { 'content-length': Buffer.byteLength(body, 'utf-8').toString(), 'content-type': 'text/html;' });
+      expect(res.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          'content-length': Buffer.byteLength(body, 'utf-8').toString(),
+        }),
+      );
 
     });
 
@@ -270,7 +292,7 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(200, { 'content-length': Buffer.byteLength(body, 'utf-8').toString() });
+      expect(res.writeHead).toHaveBeenCalledWith(200, expect.objectContaining({ 'content-length': Buffer.byteLength(body, 'utf-8').toString() }));
 
     });
 
@@ -281,7 +303,13 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(200, { 'content-length': Buffer.byteLength(body.toString(), 'utf-8').toString(), 'content-type': 'text/html' });
+      expect(res.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          'content-length': Buffer.byteLength(body.toString(), 'utf-8').toString(),
+          'content-type': 'text/html',
+        }),
+      );
 
     });
 
@@ -291,7 +319,7 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(409, { 'content-length': Buffer.byteLength('Internal Server Error', 'utf-8').toString() });
+      expect(res.writeHead).toHaveBeenCalledWith(409, expect.any(Object));
       expect(res.write).toHaveBeenCalledWith('Internal Server Error');
 
     });
@@ -302,7 +330,7 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(500, { 'content-length': Buffer.byteLength('Internal Server Error', 'utf-8').toString() });
+      expect(res.writeHead).toHaveBeenCalledWith(500, expect.any(Object));
       expect(res.write).toHaveBeenCalledWith('Internal Server Error');
 
     });
@@ -313,8 +341,35 @@ describe('NodeHttpRequestResponseHandler', () => {
 
       await lastValueFrom(handler.handle(streamMock));
 
-      expect(res.writeHead).toHaveBeenCalledWith(500, { 'content-length': Buffer.byteLength('Internal Server Error', 'utf-8').toString() });
+      expect(res.writeHead).toHaveBeenCalledWith(500, expect.any(Object));
       expect(res.write).toHaveBeenCalledWith('Internal Server Error');
+
+    });
+
+    it('should write strict-transport-security header to the response', async () => {
+
+      await lastValueFrom(handler.handle(streamMock));
+      expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          'strict-transport-security': 'max-age=7200; includeSubDomains',
+        }),
+      );
+
+    });
+
+    it('should write strict-transport-security header to the response, but not include "includeSubDomains" if specified', async () => {
+      handler = new NodeHttpRequestResponseHandler(
+        nestedHttpHandler,
+        { includeSubDomains: false, maxAge: 5000 },
+      );
+      await lastValueFrom(handler.handle(streamMock));
+      expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
+        200,
+        expect.objectContaining({
+          'strict-transport-security': 'max-age=5000',
+        }),
+      );
 
     });
 

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
@@ -25,7 +25,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
    */
   constructor(
     private httpHandler: HttpHandler,
-    private hsts: { maxAge: number; includeSubDomains: boolean } = { maxAge: 7200, includeSubDomains: true },
+    private hsts?: { maxAge: number; includeSubDomains: boolean },
   ) {
 
     if (!httpHandler) {
@@ -215,7 +215,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
         const extraHeaders = {
           ... (body !== undefined && body !== null && !response.headers['content-type'] && !response.headers['Content-Type'] && typeof response.body !== 'string' && !(response.body instanceof Buffer)) && { 'content-type': 'application/json' },
           ... (body !== undefined && body !== null) && { 'content-length': Buffer.byteLength(body, charsetString).toString() },
-          'strict-transport-security': `max-age=${this.hsts.maxAge}${this.hsts.includeSubDomains ? '; includeSubDomains' : ''}`,
+          ... (this.hsts) && { 'strict-transport-security': `max-age=${this.hsts.maxAge}${this.hsts.includeSubDomains ? '; includeSubDomains' : ''}` },
         };
 
         return of({

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
@@ -25,6 +25,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
    */
   constructor(
     private httpHandler: HttpHandler,
+    private poweredBy = 'handlers.js',
     private hsts?: { maxAge: number; includeSubDomains: boolean },
   ) {
 
@@ -216,6 +217,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
           ... (body !== undefined && body !== null && !response.headers['content-type'] && !response.headers['Content-Type'] && typeof response.body !== 'string' && !(response.body instanceof Buffer)) && { 'content-type': 'application/json' },
           ... (body !== undefined && body !== null) && { 'content-length': Buffer.byteLength(body, charsetString).toString() },
           ... (this.hsts) && { 'strict-transport-security': `max-age=${this.hsts.maxAge}${this.hsts.includeSubDomains ? '; includeSubDomains' : ''}` },
+          'x-powered-by': this.poweredBy,
         };
 
         return of({

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
@@ -23,7 +23,10 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
    *
    * @param { HttpHandler } httpHandler - the handler through which to pass incoming requests.
    */
-  constructor(private httpHandler: HttpHandler) {
+  constructor(
+    private httpHandler: HttpHandler,
+    private hsts: { maxAge: number; includeSubDomains: boolean } = { maxAge: 7200, includeSubDomains: true },
+  ) {
 
     if (!httpHandler) {
 
@@ -212,6 +215,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
         const extraHeaders = {
           ... (body !== undefined && body !== null && !response.headers['content-type'] && !response.headers['Content-Type'] && typeof response.body !== 'string' && !(response.body instanceof Buffer)) && { 'content-type': 'application/json' },
           ... (body !== undefined && body !== null) && { 'content-length': Buffer.byteLength(body, charsetString).toString() },
+          'strict-transport-security': `max-age=${this.hsts.maxAge}${this.hsts.includeSubDomains ? '; includeSubDomains' : ''}`,
         };
 
         return of({

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -83,7 +83,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 99.38,
-        "branches": 98.1,
+        "branches": 98.12,
         "functions": 99.18,
         "lines": 99.55
       }

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -83,7 +83,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 99.38,
-        "branches": 98.12,
+        "branches": 98.1,
         "functions": 99.18,
         "lines": 99.55
       }

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -83,7 +83,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 99.38,
-        "branches": 98.01,
+        "branches": 98.05,
         "functions": 99.17,
         "lines": 99.55
       }

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -83,7 +83,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 99.38,
-        "branches": 98.05,
+        "branches": 98.08,
         "functions": 99.17,
         "lines": 99.55
       }

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -83,8 +83,8 @@
     "coverageThreshold": {
       "global": {
         "statements": 99.38,
-        "branches": 98.08,
-        "functions": 99.17,
+        "branches": 98.1,
+        "functions": 99.18,
         "lines": 99.55
       }
     },


### PR DESCRIPTION
## Changes (from [this TA](https://digita.atlassian.net/wiki/spaces/USEID/pages/1867546625/TA+WebID+registry+v2))


- [x] In handlersjs-http, add a vary: string[] = [] constructor argument to the HttpHandlerOperation, such that varying headers may be set in the configuration of each operation. Use these vary lists in the RoutedHttpRequestHandler to add a vary: ... header to the response, containing the configured headers. For every WebID registry API endpoint, configure all operations with vary: [ "Accept", "Authorization", "Origin" ], which should result in a vary: Accept, Authorization, Origin response header.

- [x]  ~~Also in HttpHandlerOperation, add a date header to every response, set to current date and time  in UTC. Add a boolean constructor argument addDateHeader: boolean = true, which can switch off this behavior.~~ => added by node response object by default

- [x] ~~In HttpHandlerRoute~~ => In HttpRequestResponseHandler, add an optional constructor argument poweredBy: string = "Handlers.js". Use this parameter in RoutedHttpRequestHandler to add a header called x-powered-by to the response. In the [use.id](http://use.id/) configuration, set this to "use.id".

- [x] In NodeHttpRequestResponseHandler, add a constructor argument  hsts: { maxAge: int; includeSubDomains: boolean } ~~= { maxAge: 7200, includeSubDomains: true }~~. Use these values to add a strict-transport-security: max-age=x; includeSubDomains header to the response.
