### PR TITLE
fix: return correct vary header

### DIFF
--- a/packages/handlersjs-http/lib/handlers/http-cors-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/http-cors-request.handler.spec.ts
@@ -230,7 +230,7 @@ describe('HttpCorsRequestHandler', () => {
     it('should keep the vary header from its child handler', async () => {
 
       handler = {
-        handle: jest.fn().mockReturnValue(of({ headers: { vary: 'accept, origin'}, status: 200, body: 'handler done' } as HttpHandlerResponse)),
+        handle: jest.fn().mockReturnValue(of({ headers: { vary: 'accept, origin' }, status: 200, body: 'handler done' } as HttpHandlerResponse)),
       };
 
       service = new HttpCorsRequestHandler(handler, { credentials: true }, true);

--- a/packages/handlersjs-http/lib/handlers/http-cors-request.handler.spec.ts
+++ b/packages/handlersjs-http/lib/handlers/http-cors-request.handler.spec.ts
@@ -227,6 +227,27 @@ describe('HttpCorsRequestHandler', () => {
 
     });
 
+    it('should keep the vary header from its child handler', async () => {
+
+      handler = {
+        handle: jest.fn().mockReturnValue(of({ headers: { vary: 'accept, origin'}, status: 200, body: 'handler done' } as HttpHandlerResponse)),
+      };
+
+      service = new HttpCorsRequestHandler(handler, { credentials: true }, true);
+
+      const response = await lastValueFrom(service.handle(context));
+
+      expect(response.headers['access-control-allow-origin']).toEqual(context.request.headers.origin);
+      expect(response.headers.vary).toEqual('accept, origin');
+
+      context.request.method = 'OPTIONS';
+      const responseOptions = await lastValueFrom(service.handle(context));
+
+      expect(responseOptions.headers['access-control-allow-origin']).toEqual(context.request.headers.origin);
+      expect(responseOptions.headers.vary).toEqual('accept, origin');
+
+    });
+
   });
 
 });

--- a/packages/handlersjs-http/lib/handlers/http-cors-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/http-cors-request.handler.ts
@@ -88,7 +88,7 @@ export class HttpCorsRequestHandler implements HttpHandler {
 
             ... response.headers,
             ... allowOrigin && ({
-              ... (allowOrigin !== '*') && { 'vary': 'origin' },
+              ... (allowOrigin !== '*') && { 'vary': [ ... new Set([ ... response.headers.vary?.split(',').map((v) => v.trim().toLowerCase()) ?? [], `origin` ])].join(', ') },
               'access-control-allow-origin': allowOrigin,
               'access-control-allow-methods': (allowMethods ?? routeMethods ?? allMethods).join(', '),
               ... (allowHeadersOrRequested) && { 'access-control-allow-headers': allowHeadersOrRequested },
@@ -113,7 +113,7 @@ export class HttpCorsRequestHandler implements HttpHandler {
             ... response.headers,
             ... allowOrigin && ({
               'access-control-allow-origin': allowOrigin,
-              ... (allowOrigin !== '*') && { 'vary': 'origin' },
+              ... (allowOrigin !== '*') && { 'vary': [ ... new Set([ ... response.headers.vary?.split(',').map((v) => v.trim().toLowerCase()) ?? [], `origin` ])].join(', ') },
               ... (credentials) && { 'access-control-allow-credentials': 'true' },
               ... (exposeHeaders) && { 'access-control-expose-headers': exposeHeaders.join(',') },
             }),

--- a/packages/handlersjs-http/lib/handlers/http-cors-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/http-cors-request.handler.ts
@@ -88,7 +88,7 @@ export class HttpCorsRequestHandler implements HttpHandler {
 
             ... response.headers,
             ... allowOrigin && ({
-              ... (allowOrigin !== '*') && { 'vary': [ ... new Set([ ... response.headers.vary?.split(',').map((v) => v.trim().toLowerCase()) ?? [], `origin` ])].join(', ') },
+              ... (allowOrigin !== '*') && { 'vary': [ ... new Set([ ... response.headers.vary?.split(',').map((v) => v.trim().toLowerCase()) ?? [], `origin` ]) ].join(', ') },
               'access-control-allow-origin': allowOrigin,
               'access-control-allow-methods': (allowMethods ?? routeMethods ?? allMethods).join(', '),
               ... (allowHeadersOrRequested) && { 'access-control-allow-headers': allowHeadersOrRequested },
@@ -113,7 +113,7 @@ export class HttpCorsRequestHandler implements HttpHandler {
             ... response.headers,
             ... allowOrigin && ({
               'access-control-allow-origin': allowOrigin,
-              ... (allowOrigin !== '*') && { 'vary': [ ... new Set([ ... response.headers.vary?.split(',').map((v) => v.trim().toLowerCase()) ?? [], `origin` ])].join(', ') },
+              ... (allowOrigin !== '*') && { 'vary': [ ... new Set([ ... response.headers.vary?.split(',').map((v) => v.trim().toLowerCase()) ?? [], `origin` ]) ].join(', ') },
               ... (credentials) && { 'access-control-allow-credentials': 'true' },
               ... (exposeHeaders) && { 'access-control-expose-headers': exposeHeaders.join(',') },
             }),

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -83,8 +83,8 @@
     "coverageThreshold": {
       "global": {
         "statements": 99.38,
-        "branches": 98.1,
-        "functions": 99.18,
+        "branches": 98.13,
+        "functions": 99.19,
         "lines": 99.55
       }
     },


### PR DESCRIPTION
If in the `HttpCorsRequestHandler` `credentials` was set to `true` and a `origin` header was present in the request. The `vary` header set in its child handler would be overwritten.

This change will keep the previous value from the child handler and add `origin` to it if it was not present already.