### PR TITLE
chore: allow versioning on main branch

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -11,7 +11,7 @@
     },
     "version": {
       "allowBranch": [
-        "develop"
+        "main"
       ],
       "conventionalCommits": true,
       "exact": true,


### PR DESCRIPTION
was still set to `develop`