### PR TITLE
fix: don't log buffers

### DIFF
--- a/packages/handlersjs-http/lib/handlers/http-cors-request.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/http-cors-request.handler.ts
@@ -81,7 +81,7 @@ export class HttpCorsRequestHandler implements HttpHandler {
           ... response,
           headers: cleanHeaders(response.headers),
         })),
-        tap((response) => this.logger.info('Configuring CORS headers for response', response)),
+        tap((response) => this.logger.info('Configuring CORS headers for response')),
         map((response) => ({
           ... response,
           headers: {
@@ -106,7 +106,7 @@ export class HttpCorsRequestHandler implements HttpHandler {
       this.logger.info('Processing CORS request', noCorsRequestContext);
 
       return this.handler.handle(noCorsRequestContext).pipe(
-        tap((response) => this.logger.info('Configuring CORS headers for response', response)),
+        tap((response) => this.logger.info('Configuring CORS headers for response')),
         map((response) => ({
           ... response,
           headers: {

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
@@ -65,7 +65,8 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
 
   private parseResponseBody(body: unknown, contentType?: string) {
 
-    this.logger.info('Parsing response body', { body, contentType });
+    // don't log the body if it is a buffer. It results in a long, illegible log.
+    this.logger.info('Parsing response body', { body: body instanceof Buffer ? 'Buffer' : body, contentType });
 
     if (contentType?.startsWith('application/json')) {
 

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -83,7 +83,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 99.38,
-        "branches": 98.13,
+        "branches": 97.69,
         "functions": 99.19,
         "lines": 99.55
       }


### PR DESCRIPTION
Logging a Buffer doesn't make much sense. We can't read or understand a buffer anyway, so simply logging the fact that the body is a buffer is fine, and results in a less cluttered log.