### PR TITLE
fix: ErrorHandler logging + incorrect HSTS headers

### DIFF
--- a/packages/handlersjs-http/lib/handlers/error.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/error.handler.ts
@@ -69,12 +69,11 @@ export class ErrorHandler implements HttpHandler {
 
   handle(context: HttpHandlerContext): Observable<HttpHandlerResponse>{
 
-    context.logger.setLabel(this);
-
     return this.nestedHandler.handle(context).pipe(
       catchError((error) => {
 
-        context.logger.error('Error occurred: ', { error });
+        context.logger.setLabel(this);
+        context.logger.warn('Error occurred: ', { error });
 
         const status = error?.statusCode ?? error.status;
         const message = error?.message ?? error.body;

--- a/packages/handlersjs-http/lib/handlers/error.handler.ts
+++ b/packages/handlersjs-http/lib/handlers/error.handler.ts
@@ -73,7 +73,7 @@ export class ErrorHandler implements HttpHandler {
       catchError((error) => {
 
         context.logger.setLabel(this);
-        context.logger.warn('Error occurred: ', { error });
+        context.logger.error('Error occurred: ', { error });
 
         const status = error?.statusCode ?? error.status;
         const message = error?.message ?? error.body;

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
@@ -247,7 +247,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
         const extraHeaders = {
           ... (body !== undefined && body !== null && !response.headers['content-type'] && !response.headers['Content-Type'] && typeof response.body !== 'string' && !(response.body instanceof Buffer)) && { 'content-type': 'application/json' },
           ... (body !== undefined && body !== null) && { 'content-length': Buffer.byteLength(body, charsetString).toString() },
-          ... (this.hsts) && { 'strict-transport-security': `max-age=${this.hsts.maxAge}${this.hsts.includeSubDomains ? '; includeSubDomains' : ''}` },
+          ... (this.hsts?.maxAge) && { 'strict-transport-security': `max-age=${this.hsts.maxAge}${this.hsts.includeSubDomains ? '; includeSubDomains' : ''}` },
           'x-powered-by': this.poweredBy,
           'x-request-id': this.requestId,
           'x-correlation-id': this.correlationId,


### PR DESCRIPTION
## Bugs fixed

- The `strict-transport-security` header would be added as `max-age=undefined` when no hsts object was passed to contructor of `NodeHttpRequestResponseHandler`
- `ErrorHandler` did not set its logging label correctly