### PR TITLE
fix: typo logged -> logger

### DIFF
--- a/packages/handlersjs-logging/lib/main.spec.ts
+++ b/packages/handlersjs-logging/lib/main.spec.ts
@@ -7,7 +7,7 @@ describe('main', () => {
 
     it('should throw an error when no logger is set', () => {
 
-      expect(() => getLogger()).toThrowError('No logger was set. Set a logged using setLogger()');
+      expect(() => getLogger()).toThrowError('No logger was set. Set a logger using setLogger()');
 
     });
 

--- a/packages/handlersjs-logging/lib/main.ts
+++ b/packages/handlersjs-logging/lib/main.ts
@@ -21,7 +21,7 @@ export const setLogger = (
 export const getLogger = (): Logger => {
 
   const logger = getGlobalLogger();
-  if (!logger) throw new Error('No logger was set. Set a logged using setLogger()');
+  if (!logger) throw new Error('No logger was set. Set a logger using setLogger()');
 
   return logger;
 


### PR DESCRIPTION
Fixes typo in `main.ts`.