### PR TITLE
fix: don't crash server when a non HTTP method was provided

### DIFF
--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
@@ -120,6 +120,19 @@ describe('NodeHttpRequestResponseHandler', () => {
 
     });
 
+    it('should return 405 when request method is not an HTTP method', async () => {
+
+      // This is a valid header in the WebDAV protocol
+      streamMock.requestStream.method = 'PROPFIND';
+      await lastValueFrom(handler.handle(streamMock));
+
+      expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
+        405,
+        'Only HTTP methods are allowed!',
+      );
+
+    });
+
     it('throws when headers is null/undefined', async () => {
 
       streamMock.requestStream.headers = null;

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
@@ -110,6 +110,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
 
     if (!nodeHttpStreams.requestStream) {
 
+      // No request was received, this path is technically impossible to reach
       this.logger.error('No request stream received', { nodeHttpStreams });
 
       return throwError(() => new Error('request stream cannot be null or undefined.'));
@@ -118,6 +119,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
 
     if (!nodeHttpStreams.requestStream.headers) {
 
+      // No request headers were received, this path is technically impossible to reach
       this.logger.error('No request headers received', { requestStream: nodeHttpStreams.requestStream });
 
       return throwError(() => new Error('headers of the request cannot be null or undefined.'));
@@ -138,6 +140,7 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
 
     if (!nodeHttpStreams.responseStream) {
 
+      // No response was received, this path is technically impossible to reach
       this.logger.error('No response stream received', { nodeHttpStreams });
 
       return throwError(() => new Error('response stream cannot be null or undefined.'));
@@ -148,19 +151,36 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
 
     if (!url) {
 
+      // No request url was received, this path is technically impossible to reach
       this.logger.warn('No url received', { requestStream: nodeHttpStreams.requestStream });
 
       return throwError(() => new Error('url of the request cannot be null or undefined.'));
 
     }
 
+    // Check if the request method is an HTTP method + this ensures typing throughout the file
     const method = Object.values(HttpMethods).find((m) => m === nodeHttpStreams.requestStream.method);
 
     if (!method) {
 
-      this.logger.warn('No method received', { requestStream: nodeHttpStreams.requestStream });
+      if (nodeHttpStreams.requestStream.method) {
 
-      return throwError(() => new Error('method of the request cannot be null or undefined.'));
+        // An unsupported method was received
+        this.logger.warn('Invalid method received', { method: nodeHttpStreams.requestStream.method });
+        this.logger.clearVariables();
+        nodeHttpStreams.responseStream.writeHead(405, 'Only HTTP methods are allowed!');
+        nodeHttpStreams.responseStream.end();
+
+        return of(void 0);
+
+      } else {
+
+        // No request method was received, this path is technically impossible to reach
+        this.logger.warn('No method received', { requestStream: nodeHttpStreams.requestStream });
+
+        return throwError(() => new Error('method of the request cannot be null or undefined.'));
+
+      }
 
     }
 

--- a/packages/handlersjs-http/package.json
+++ b/packages/handlersjs-http/package.json
@@ -85,7 +85,7 @@
     "coverageThreshold": {
       "global": {
         "statements": 99.79,
-        "branches": 99.1,
+        "branches": 99.11,
         "functions": 99.15,
         "lines": 100
       }


### PR DESCRIPTION
## Changes in this PR

- Do not crash the server when a non HTTP method is provided, for instance: WebDAV's PROPFIND. (used in unit tests)