### PR TITLE
fix: correct status on unknown method

### DIFF
--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.spec.ts
@@ -120,15 +120,15 @@ describe('NodeHttpRequestResponseHandler', () => {
 
     });
 
-    it('should return 405 when request method is not an HTTP method', async () => {
+    it('should return 501 when request method is not an HTTP method', async () => {
 
       // This is a valid header in the WebDAV protocol
       streamMock.requestStream.method = 'PROPFIND';
       await lastValueFrom(handler.handle(streamMock));
 
       expect(streamMock.responseStream.writeHead).toHaveBeenCalledWith(
-        405,
-        'Only HTTP methods are allowed!',
+        501,
+        { 'Content-Type': 'application/json' },
       );
 
     });

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
@@ -166,9 +166,13 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
       if (nodeHttpStreams.requestStream.method) {
 
         // An unsupported method was received
-        this.logger.warn('Invalid method received', { method: nodeHttpStreams.requestStream.method });
+        this.logger.debug('Invalid method received', { method: nodeHttpStreams.requestStream.method });
         this.logger.clearVariables();
-        nodeHttpStreams.responseStream.writeHead(405, 'Only HTTP methods are allowed!');
+        nodeHttpStreams.responseStream.writeHead(501, { 'Content-Type': 'application/json' });
+        nodeHttpStreams.responseStream.write(JSON.stringify({
+          error: 'http_request_method_not_valid',
+          error_description: 'This is not a known HTTP verb'
+        }));
         nodeHttpStreams.responseStream.end();
 
         return of(void 0);

--- a/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
+++ b/packages/handlersjs-http/lib/servers/node/node-http-request-response.handler.ts
@@ -169,10 +169,12 @@ export class NodeHttpRequestResponseHandler implements NodeHttpStreamsHandler {
         this.logger.debug('Invalid method received', { method: nodeHttpStreams.requestStream.method });
         this.logger.clearVariables();
         nodeHttpStreams.responseStream.writeHead(501, { 'Content-Type': 'application/json' });
+
         nodeHttpStreams.responseStream.write(JSON.stringify({
           error: 'http_request_method_not_valid',
-          error_description: 'This is not a known HTTP verb'
+          error_description: 'This is not a known HTTP verb',
         }));
+
         nodeHttpStreams.responseStream.end();
 
         return of(void 0);


### PR DESCRIPTION
Return a 501 instead of a 405 when a non HTTP method is received.